### PR TITLE
Migrate Google Fonts to @fontsource

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@fontsource/noto-sans": "^5.2.7",
+    "@fontsource/poppins": "^5.2.6",
     "@playwright/test": "^1.54.1",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
       '@eslint/js':
         specifier: ^9.29.0
         version: 9.29.0
+      '@fontsource/noto-sans':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/poppins':
+        specifier: ^5.2.6
+        version: 5.2.6
       '@playwright/test':
         specifier: ^1.54.1
         version: 1.54.1
@@ -358,6 +364,12 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+
+  '@fontsource/noto-sans@5.2.7':
+    resolution: {integrity: sha512-mTpMSMft6Nb+ZSF4DSiJVYnLzKCRjHNFieZ/swuxSDQK+v1hjUeDTBxLHKUdfmC+ZPg6TUEWw4oRq2ltnDbSjQ==}
+
+  '@fontsource/poppins@5.2.6':
+    resolution: {integrity: sha512-NFr0121+vWCfzLDVvSZOzwAjRUaNj6QHA9gtUh/KHHoWf1Qn23EkwVFs63XZ6UtF5K1b3UNmCx77YEMGgV7BOQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2725,6 +2737,10 @@ snapshots:
       levn: 0.4.1
 
   '@fastify/busboy@2.1.1': {}
+
+  '@fontsource/noto-sans@5.2.7': {}
+
+  '@fontsource/poppins@5.2.6': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/colors.css';
+import '@styles/fonts.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 
@@ -83,12 +84,6 @@ import { ClientRouter } from 'astro:transitions';
     </style>
   </body>
 </html>
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-  rel="stylesheet"
-/>
 <style>
   @view-transition {
     navigation: auto;

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,0 +1,7 @@
+@import '@fontsource/noto-sans/latin-400.css';
+@import '@fontsource/noto-sans/latin-500.css';
+@import '@fontsource/noto-sans/latin-600.css';
+
+@import '@fontsource/poppins/latin-500.css';
+@import '@fontsource/poppins/latin-600.css';
+@import '@fontsource/poppins/latin-800.css';


### PR DESCRIPTION
This PR replaces Google Fonts with locally hosted @fontsource packages.

Changes:
- Add @fontsource for Noto Sans (400/500/600) and Poppins (500/600/800)
- Import fonts via src/styles/fonts.css and layout head
- Remove external Google Fonts <link> tags from default layout

Benefits:
- Improved performance (no render-blocking Google Fonts)
- Better privacy and reliability
- Loads only used weights as per global styles (body uses Noto Sans; headings use Poppins; weights 400/500/600/800)

Validated:
- Astro build passes
- Visual check via preview; no style regressions expected.

