### PR TITLE
feat: Convert interstitial to CSS-only implementation

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -78,21 +78,21 @@ const { title, description = 'Astro description' } = Astro.props;
     min-height: 100vh;
   }
 
-  /* Interstitial is visible by default with immediate dark theme styling */
+  /* Interstitial: Show while any custom elements are not yet defined */
   #interstitial {
-    opacity: 1;
-    pointer-events: auto;
-    transition: opacity 0.3s ease-in-out;
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: oklch(0.205 0 0); /* --color-neutral-900 dark theme */
+    background-color: oklch(0.205 0 0); /* Dark theme background */
     z-index: 9999;
     display: flex;
     align-items: center;
     justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
   }
 
   #interstitial .interstitial-content {
@@ -102,7 +102,7 @@ const { title, description = 'Astro description' } = Astro.props;
   }
 
   #interstitial .interstitial-planet {
-    fill: oklch(0.91 0.096 180.426); /* --color-teal-200 dark theme */
+    fill: oklch(0.91 0.096 180.426); /* Teal color for dark theme */
     animation: pulse 2s ease-in-out infinite;
   }
 
@@ -116,20 +116,22 @@ const { title, description = 'Astro description' } = Astro.props;
     }
   }
 
-  /* Main content is hidden by default */
-  .hidden-until-loaded {
-    opacity: 0;
-    transition: opacity 0.3s ease-in-out;
-  }
-
-  /* Hide interstitial and show main content when all custom elements are defined */
-  body:not(:has(*:not(:defined))) #interstitial {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  body:not(:has(*:not(:defined))) .hidden-until-loaded {
+  /* Show interstitial when any custom elements are not defined */
+  *:not(:defined) ~ #interstitial,
+  body:has(*:not(:defined)) #interstitial {
     opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* Hide main content while custom elements are loading */
+  body:has(*:not(:defined)) .hidden-until-loaded {
+    opacity: 0;
+  }
+
+  /* Show main content when all custom elements are defined */
+  .hidden-until-loaded {
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
   }
 
   main {
@@ -189,62 +191,7 @@ const { title, description = 'Astro description' } = Astro.props;
     }
   });
 
-  // Interstitial management with fallback for browsers that don't support :has()
-  function checkCustomElements() {
-    const customElementTags = [
-      'contact-component',
-      'theme-toggle',
-      'loading-bar',
-    ];
-    const allDefined = customElementTags.every(tag => customElements.get(tag));
-    const interstitial = document.getElementById('interstitial') as HTMLElement;
-    const hiddenContent = document.querySelector(
-      '.hidden-until-loaded'
-    ) as HTMLElement;
-
-    if (allDefined) {
-      // All custom elements are defined, hide interstitial and show content
-      if (interstitial) {
-        interstitial.style.opacity = '0';
-        interstitial.style.pointerEvents = 'none';
-      }
-      if (hiddenContent) {
-        hiddenContent.style.opacity = '1';
-      }
-      return true;
-    }
-    return false;
-  }
-
-  // Check immediately
-  if (!checkCustomElements()) {
-    // Poll for custom element definition
-    const checkInterval = setInterval(() => {
-      if (checkCustomElements()) {
-        clearInterval(checkInterval);
-      }
-    }, 50);
-
-    // Cleanup after maximum wait time
-    setTimeout(() => {
-      clearInterval(checkInterval);
-      // Force show content after timeout
-      const interstitial = document.getElementById(
-        'interstitial'
-      ) as HTMLElement;
-      const hiddenContent = document.querySelector(
-        '.hidden-until-loaded'
-      ) as HTMLElement;
-      if (interstitial) {
-        interstitial.style.opacity = '0';
-        interstitial.style.pointerEvents = 'none';
-      }
-      if (hiddenContent) {
-        hiddenContent.style.opacity = '1';
-      }
-    }, 3000);
-  }
-
+  // Analytics - deferred loading
   let analyticsActivated = false;
   const activateAnalytics = () => {
     if (analyticsActivated) return;


### PR DESCRIPTION
## Summary

Converts the interstitial loading element from a JavaScript-based implementation to a pure CSS solution, removing all JavaScript polling and custom element checking logic.

## Key Changes

### JavaScript Removal
- ✅ Removed `checkCustomElements()` function and interval polling
- ✅ Eliminated setTimeout fallback mechanism 
- ✅ Removed manual DOM manipulation of interstitial opacity/pointer-events
- ✅ Kept essential functionality: loading bar, analytics, theme management

### CSS-Only Implementation
- ✅ Simplified CSS selectors using `:has(*:not(:defined))` and `*:not(:defined)`
- ✅ Browser-native detection of undefined custom elements
- ✅ Maintained loading animation and dark theme styling
- ✅ Preserved smooth transitions and proper z-index layering

## Benefits

1. **Performance**: Eliminates JavaScript polling overhead (50ms intervals)
2. **Simplicity**: Pure CSS solution follows "less noise, more meaning" philosophy  
3. **Reliability**: Browser-native `:not(:defined)` detection instead of custom logic
4. **Maintainability**: Fewer moving parts, no timeout edge cases to handle

## Testing

- ✅ **Homepage**: Loads correctly, interstitial hides when custom elements defined
- ✅ **About Page**: Profile image and cards render properly
- ✅ **Consultation Page**: All consultation services and components visible
- ✅ **Navigation**: Loading bar integration continues to work correctly
- ✅ **Theme System**: Maintains dark theme styling and color variables

## Implementation Details

**Before**: Complex JavaScript with polling, timeouts, and manual DOM manipulation
**After**: Clean CSS selectors that react to custom element definition state

```css
/* Show interstitial when any custom elements are not defined */
*:not(:defined) ~ #interstitial,
body:has(*:not(:defined)) #interstitial {
  opacity: 1;
  pointer-events: auto;
}
```

Follows Andrew's preferences for:
- ✅ Minimal, composable changes
- ✅ Atomic CSS principles  
- ✅ Performance optimization
- ✅ Clean, maintainable code

**Ready for review and merge.**